### PR TITLE
Use NVS instead of RTC for user config

### DIFF
--- a/src/CaptiveConfigServer.cpp
+++ b/src/CaptiveConfigServer.cpp
@@ -14,12 +14,12 @@ WebServer server(80);
 
 String buildConfigHtml(const UserConfig* config) {
   auto html = String(ConfigHtml);
-  html.replace("{{username}}", config->username);
-  html.replace("{{wifi-ssid}}", config->wifiSSID);
-  html.replace("{{wifi-password}}", config->wifiPassword);
-  html.replace("{{interval}}", String(config->syncInterval));
-  html.replace("{{dark-mode}}", config->darkMode ? "checked" : "");
-  html.replace("{{url}}", config->apiUrl);
+  html.replace("{{wifi-ssid}}", config->wifi.ssid);
+  html.replace("{{wifi-password}}", config->wifi.password);
+  html.replace("{{username}}", config->commitGraph.username);
+  html.replace("{{url}}", config->commitGraph.apiUrl);
+  html.replace("{{interval}}", String(config->energy.syncInterval));
+  html.replace("{{dark-mode}}", config->display.darkMode ? "checked" : "");
   return html;
 }
 
@@ -38,16 +38,15 @@ void CaptiveConfigServer::begin() {
 
   server.on("/submit", [this] {
     // Read the form values from the param and store them in RTC memory
-    strcpy(this->config->username, server.arg("username").c_str());
-    strcpy(this->config->username, server.arg("username").c_str());
-    strcpy(this->config->wifiSSID, server.arg("wifi-ssid").c_str());
-    strcpy(this->config->wifiPassword, server.arg("wifi-password").c_str());
-    strcpy(this->config->apiUrl, server.arg("url").c_str());
-    this->config->syncInterval = server.arg("interval").toInt();
-    this->config->darkMode = server.hasArg("dark-mode");
+    strcpy(this->config->wifi.ssid, server.arg("wifi-ssid").c_str());
+    strcpy(this->config->wifi.password, server.arg("wifi-password").c_str());
+    strcpy(this->config->commitGraph.username, server.arg("username").c_str());
+    strcpy(this->config->commitGraph.apiUrl, server.arg("url").c_str());
+    this->config->energy.syncInterval = server.arg("interval").toInt();
+    this->config->display.darkMode = server.hasArg("dark-mode");
     this->loaded = true;
 
-    Serial.println("Saved updated config");
+    Serial.println("Recieved updated config");
 
     server.send(200, "text/html", ConfigSavedHtml);
     delay(100);  // Wait for the response to be sent
@@ -67,7 +66,7 @@ bool CaptiveConfigServer::getConfig() const {
   const unsigned long configStartMillis = millis();
 
   while (true) {
-    if (this->loaded) {
+    if (loaded) {
       return true;
     }
 

--- a/src/ContributionsApi.cpp
+++ b/src/ContributionsApi.cpp
@@ -12,7 +12,8 @@ HTTPClient http;
 ContributionsApi::ContributionsApi(UserConfig* config) { this->config = config; }
 
 String ContributionsApi::fetchHttpResponse() const {
-  const String url = String(this->config->apiUrl) + String(this->config->username) + "?weeks=" + String(WEEKS);
+  const String url =
+      String(config->commitGraph.apiUrl) + String(config->commitGraph.username) + "?weeks=" + String(WEEKS);
 
   Serial.println("Fetching contributions data from: " + url);
   client.setInsecure();
@@ -28,9 +29,9 @@ String ContributionsApi::fetchHttpResponse() const {
   return payload;
 }
 
-bool ContributionsApi::fetchContributionsData(CommitGraphContributions* contributions) const {
+bool ContributionsApi::fetchContributionsData(Data* contributions) const {
   JsonDocument doc;
-  String payload = this->fetchHttpResponse();
+  String payload = fetchHttpResponse();
   // Parse response
   // 2 weeks = [1, 0, 3, 1, 4, 0, 0, 1, 0, 3, 1, 4, 0, -1, -1]
   const DeserializationError error = deserializeJson(doc, payload);

--- a/src/ContributionsApi.h
+++ b/src/ContributionsApi.h
@@ -4,14 +4,14 @@
 #include "DeviceConfig.h"
 #include "UserConfig.h"
 
-struct CommitGraphContributions {
-  int week[WEEKS * 7] = {};
-};
-
 class ContributionsApi {
  public:
+  struct Data {
+    int week[WEEKS * 7] = {};
+  };
+
   explicit ContributionsApi(UserConfig* config);
-  bool fetchContributionsData(CommitGraphContributions* contributions) const;
+  bool fetchContributionsData(Data* contributions) const;
 
  private:
   UserConfig* config;

--- a/src/DisplayController.cpp
+++ b/src/DisplayController.cpp
@@ -5,14 +5,14 @@
 
 #include "assets/muMatrix8ptRegular.h"
 
-DisplayColors::DisplayColors(const bool darkMode) {
+DisplayController::Colors::Colors(const bool darkMode) {
   background = darkMode ? GxEPD_BLACK : GxEPD_WHITE;
   lightForeground = darkMode ? GxEPD_DARKGREY : GxEPD_LIGHTGREY;
   darkForeground = darkMode ? GxEPD_LIGHTGREY : GxEPD_DARKGREY;
   foreground = darkMode ? GxEPD_WHITE : GxEPD_BLACK;
 }
 
-uint16_t DisplayColors::fromLevel(const int level) const {
+uint16_t DisplayController::Colors::fromLevel(const int level) const {
   if (level <= 0) return background;
   if (level == 1) return lightForeground;
   if (level == 2) return darkForeground;

--- a/src/DisplayController.h
+++ b/src/DisplayController.h
@@ -3,18 +3,18 @@
 #include <Arduino.h>
 #include <DeviceConfig.h>
 
-struct DisplayColors {
-  explicit DisplayColors(bool darkMode);
-  uint16_t fromLevel(int level) const;
-
-  uint16_t background;
-  uint16_t lightForeground;
-  uint16_t darkForeground;
-  uint16_t foreground;
-};
-
 class DisplayController {
  public:
+  struct Colors {
+    explicit Colors(bool darkMode);
+    uint16_t fromLevel(int level) const;
+
+    uint16_t background;
+    uint16_t lightForeground;
+    uint16_t darkForeground;
+    uint16_t foreground;
+  };
+
   explicit DisplayController(bool darkMode);
   void drawBackground();
   void drawText(const String &text, int x, int y);
@@ -22,5 +22,5 @@ class DisplayController {
   void displayAndHibernate();
 
   GxEPD2_DISPLAY_CLASS<GxEPD2_DRIVER_CLASS, GxEPD2_DRIVER_CLASS::HEIGHT> display;
-  DisplayColors colors;
+  Colors colors;
 };

--- a/src/SleepController.cpp
+++ b/src/SleepController.cpp
@@ -12,11 +12,11 @@ void SleepController::deepSleep() const {
   // button is pressed)
   esp_sleep_enable_ext0_wakeup(static_cast<gpio_num_t>(BUTTON_PIN), LOW);
 
-  Serial.println("Going to sleep for " + String(config->syncInterval) + " hours");
-  esp_deep_sleep(static_cast<unsigned long long>(3600e6) * config->syncInterval);  // syncInterval * 1 hour
+  Serial.println("Going to sleep for " + String(config->energy.syncInterval) + " hours");
+  esp_deep_sleep(static_cast<unsigned long long>(3600e6) * config->energy.syncInterval);  // syncInterval * 1 hour
 }
 
-WakeReason SleepController::getWakeReason() {
+SleepController::WakeReason SleepController::getWakeReason() {
   const esp_sleep_wakeup_cause_t wakeup_reason = esp_sleep_get_wakeup_cause();
   if (wakeup_reason == ESP_SLEEP_WAKEUP_EXT0) {
     // Wakeup caused by GPIO (external wakeup)

--- a/src/SleepController.h
+++ b/src/SleepController.h
@@ -1,15 +1,15 @@
 #pragma once
 #include "UserConfig.h"
 
-enum WakeReason {
-  BUTTON_PRESS,
-  BUTTON_HOLD,
-  TIMER,
-  UNKNOWN,
-};
-
 class SleepController {
  public:
+  enum WakeReason {
+    BUTTON_PRESS,
+    BUTTON_HOLD,
+    TIMER,
+    UNKNOWN,
+  };
+
   explicit SleepController(UserConfig *config);
   void deepSleep() const;
   static WakeReason getWakeReason();

--- a/src/UserConfig.cpp
+++ b/src/UserConfig.cpp
@@ -1,5 +1,68 @@
 #include "UserConfig.h"
 
 #include <Arduino.h>
+#include <Preferences.h>
 
-bool UserConfig::isSet() const { return strlen(wifiSSID) > 0 && strlen(username) > 0; };
+const char* UserConfig::PREFERENCES_NAMESPACE = "user_config";
+
+bool UserConfig::Wifi::isSet() const { return strlen(ssid) > 0; }
+
+bool UserConfig::CommitGraph::isSet() const { return strlen(username) > 0 && strlen(apiUrl) > 0; }
+
+bool UserConfig::isSet() const { return wifi.isSet() && commitGraph.isSet(); }
+
+UserConfig UserConfig::load() {
+  UserConfig config;
+  Preferences prefs;
+
+  if (!prefs.begin(PREFERENCES_NAMESPACE, true)) {  // true = read-only
+    Serial.println("Failed to open preferences for reading");
+    return config;  // Return default config
+  }
+
+  // Load WiFi config
+  prefs.getString("wifi_ssid", config.wifi.ssid, sizeof(config.wifi.ssid));
+  prefs.getString("wifi_pass", config.wifi.password, sizeof(config.wifi.password));
+
+  // Load Commit Graph config
+  prefs.getString("commit_user", config.commitGraph.username, sizeof(config.commitGraph.username));
+  prefs.getString("commit_url", config.commitGraph.apiUrl, sizeof(config.commitGraph.apiUrl));
+
+  // Load Display config
+  config.display.darkMode = prefs.getBool("dark_mode", false);
+
+  // Load Energy config
+  config.energy.syncInterval = prefs.getInt("sync_interval", 4);  // Default 4 hours
+
+  prefs.end();
+
+  Serial.println("Configuration loaded from preferences");
+  return config;
+}
+
+void UserConfig::save() {
+  Preferences prefs;
+
+  if (!prefs.begin(PREFERENCES_NAMESPACE, false)) {  // false = read-write
+    Serial.println("Failed to open preferences for writing");
+    return;
+  }
+
+  // Save WiFi config
+  prefs.putString("wifi_ssid", wifi.ssid);
+  prefs.putString("wifi_pass", wifi.password);
+
+  // Save Commit Graph config
+  prefs.putString("commit_user", commitGraph.username);
+  prefs.putString("commit_url", commitGraph.apiUrl);
+
+  // Save Display config
+  prefs.putBool("dark_mode", display.darkMode);
+
+  // Save Energy config
+  prefs.putInt("sync_interval", energy.syncInterval);
+
+  prefs.end();
+
+  Serial.println("Configuration saved to preferences");
+}

--- a/src/UserConfig.cpp
+++ b/src/UserConfig.cpp
@@ -3,7 +3,10 @@
 #include <Arduino.h>
 #include <Preferences.h>
 
+Preferences prefs;
+
 const char* UserConfig::PREFERENCES_NAMESPACE = "user_config";
+const int UserConfig::VERSION = 1;
 
 bool UserConfig::Wifi::isSet() const { return strlen(ssid) > 0; }
 
@@ -11,41 +14,58 @@ bool UserConfig::CommitGraph::isSet() const { return strlen(username) > 0 && str
 
 bool UserConfig::isSet() const { return wifi.isSet() && commitGraph.isSet(); }
 
-UserConfig UserConfig::load() {
-  UserConfig config;
-  Preferences prefs;
-
+bool UserConfig::load() {
   if (!prefs.begin(PREFERENCES_NAMESPACE, true)) {  // true = read-only
     Serial.println("Failed to open preferences for reading");
-    return config;  // Return default config
+    return false;  // Return default config
+  }
+
+  const int storedVersion = prefs.getInt("version", -1);
+
+  if (storedVersion == -1) {
+    Serial.println("Configuration uninitialized, using defaults");
+    prefs.end();
+    return false;
+  }
+
+  if (storedVersion != VERSION) {
+    Serial.println("Configuration changed, clearing old preferences");
+    prefs.end();
+
+    if (prefs.begin(PREFERENCES_NAMESPACE, false)) {  // false = read-write
+      prefs.clear();
+      prefs.end();
+    } else {
+      Serial.println("Failed to clear preferences");
+    }
+
+    return false;
   }
 
   // Load WiFi config
-  prefs.getString("wifi_ssid", config.wifi.ssid, sizeof(config.wifi.ssid));
-  prefs.getString("wifi_pass", config.wifi.password, sizeof(config.wifi.password));
+  prefs.getString("wifi_ssid", wifi.ssid, sizeof(wifi.ssid));
+  prefs.getString("wifi_pass", wifi.password, sizeof(wifi.password));
 
   // Load Commit Graph config
-  prefs.getString("commit_user", config.commitGraph.username, sizeof(config.commitGraph.username));
-  prefs.getString("commit_url", config.commitGraph.apiUrl, sizeof(config.commitGraph.apiUrl));
+  prefs.getString("commit_user", commitGraph.username, sizeof(commitGraph.username));
+  prefs.getString("commit_url", commitGraph.apiUrl, sizeof(commitGraph.apiUrl));
 
   // Load Display config
-  config.display.darkMode = prefs.getBool("dark_mode", false);
+  display.darkMode = prefs.getBool("dark_mode", false);
 
   // Load Energy config
-  config.energy.syncInterval = prefs.getInt("sync_interval", 4);  // Default 4 hours
+  energy.syncInterval = prefs.getInt("sync_interval", 4);  // Default 4 hours
 
   prefs.end();
 
   Serial.println("Configuration loaded from preferences");
-  return config;
+  return true;
 }
 
-void UserConfig::save() {
-  Preferences prefs;
-
+bool UserConfig::save() {
   if (!prefs.begin(PREFERENCES_NAMESPACE, false)) {  // false = read-write
     Serial.println("Failed to open preferences for writing");
-    return;
+    return false;
   }
 
   // Save WiFi config
@@ -62,7 +82,11 @@ void UserConfig::save() {
   // Save Energy config
   prefs.putInt("sync_interval", energy.syncInterval);
 
+  // Save version
+  prefs.putInt("version", VERSION);
+
   prefs.end();
 
   Serial.println("Configuration saved to preferences");
+  return true;
 }

--- a/src/UserConfig.h
+++ b/src/UserConfig.h
@@ -23,13 +23,15 @@ class UserConfig {
   };
 
   bool isSet() const;
-  static UserConfig load();
-  void save();
+  bool load();
+  bool save();
 
   Wifi wifi;
   CommitGraph commitGraph;
   Display display;
   Energy energy;
 
+ private:
   static const char *PREFERENCES_NAMESPACE;
+  static const int VERSION;
 };

--- a/src/UserConfig.h
+++ b/src/UserConfig.h
@@ -1,11 +1,35 @@
 #pragma once
-struct UserConfig {
-  char username[50] = "";
-  char wifiSSID[50] = "";
-  char wifiPassword[50] = "";
-  int syncInterval = 4;  // Hours
-  bool darkMode = false;
-  char apiUrl[100] = "https://contributions-api.harryab.com/";
+
+class UserConfig {
+ public:
+  struct Wifi {
+    char ssid[50] = "";
+    char password[50] = "";
+    bool isSet() const;
+  };
+
+  struct CommitGraph {
+    char username[50] = "";
+    char apiUrl[100] = "https://contributions-api.harryab.com/";
+    bool isSet() const;
+  };
+
+  struct Display {
+    bool darkMode = false;
+  };
+
+  struct Energy {
+    int syncInterval = 4;  // Hours
+  };
 
   bool isSet() const;
+  static UserConfig load();
+  void save();
+
+  Wifi wifi;
+  CommitGraph commitGraph;
+  Display display;
+  Energy energy;
+
+  static const char *PREFERENCES_NAMESPACE;
 };

--- a/src/WifiController.cpp
+++ b/src/WifiController.cpp
@@ -9,7 +9,7 @@ WifiController::WifiController(UserConfig *config) { this->config = config; }
 bool WifiController::connectWifi() const {
   constexpr unsigned long timeout = 6000;  // 6 seconds timeout
 
-  WiFi.begin(config->wifiSSID, config->wifiPassword);
+  WiFi.begin(config->wifi.ssid, config->wifi.password);
 
   Serial.print("\nConnecting to Wifi: ");
   const unsigned long startAttemptTime = millis();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,7 +11,7 @@
 #include "screens/CommitGraphScreen.h"
 #include "screens/ConfigModeScreen.h"
 
-UserConfig config = UserConfig::load();
+UserConfig config;
 RTC_DATA_ATTR CommitGraphScreen::State commitGraphScreenState;
 
 // Controllers
@@ -53,6 +53,10 @@ void loadConfigAndRestart() {
 void setup() {
   Serial.begin(115200);
   pinMode(BUTTON_PIN, INPUT);
+
+  // Load config from NVS
+  delay(10);  // TODO: Would love to remove this, but it seems like config.load() hangs if there is no delay in here
+  config.load();
 
   const SleepController::WakeReason wakeReason = SleepController::getWakeReason();
   if (wakeReason == SleepController::WakeReason::BUTTON_HOLD) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,12 +11,11 @@
 #include "screens/CommitGraphScreen.h"
 #include "screens/ConfigModeScreen.h"
 
-// RTC memory - Clears when the device is powered off but is retained on sleep
-RTC_DATA_ATTR UserConfig config;
-RTC_DATA_ATTR CommitGraphScreenState commitGraphScreenState;
+UserConfig config = UserConfig::load();
+RTC_DATA_ATTR CommitGraphScreen::State commitGraphScreenState;
 
 // Controllers
-DisplayController displayController(config.darkMode);
+DisplayController displayController(config.display.darkMode);
 SleepController sleepController(&config);
 WifiController wifiController(&config);
 
@@ -40,6 +39,7 @@ void loadConfigAndRestart() {
   captiveConfigServer.begin();
   if (captiveConfigServer.getConfig()) {
     Serial.println("Successfully loaded new config");
+    config.save();
     resetScreenStates();
   } else {
     Serial.println("Failed to load new config");
@@ -54,8 +54,8 @@ void setup() {
   Serial.begin(115200);
   pinMode(BUTTON_PIN, INPUT);
 
-  const WakeReason wakeReason = SleepController::getWakeReason();
-  if (wakeReason == BUTTON_HOLD) {
+  const SleepController::WakeReason wakeReason = SleepController::getWakeReason();
+  if (wakeReason == SleepController::WakeReason::BUTTON_HOLD) {
     Serial.println("Button held, entering config mode");
     loadConfigAndRestart();
     // This shouldn't be reached, as loadConfigAndRestart() will restart the device

--- a/src/screens/CommitGraphScreen.cpp
+++ b/src/screens/CommitGraphScreen.cpp
@@ -5,12 +5,12 @@
 #include "assets/WifiErrorIcon.h"
 
 // Override the contributions and return true if any changed
-bool CommitGraphScreenState::storeContributionIfChanged(const CommitGraphContributions *newContributions) {
+bool CommitGraphScreen::State::storeContributionIfChanged(const ContributionsApi::Data *newContributions) {
   bool changed = false;
 
   for (int i = 0; i < 7 * WEEKS; i++) {
-    if (this->contributions.week[i] != newContributions->week[i]) {
-      this->contributions.week[i] = newContributions->week[i];
+    if (contributions.week[i] != newContributions->week[i]) {
+      contributions.week[i] = newContributions->week[i];
       changed = true;
     }
   }
@@ -19,8 +19,7 @@ bool CommitGraphScreenState::storeContributionIfChanged(const CommitGraphContrib
 }
 
 CommitGraphScreen::CommitGraphScreen(DisplayController *displayController, WifiController *wifiController,
-                                     ContributionsApi *contributionsApi, UserConfig *config,
-                                     CommitGraphScreenState *state) {
+                                     ContributionsApi *contributionsApi, UserConfig *config, State *state) {
   this->displayController = displayController;
   this->wifiController = wifiController;
   this->contributionsApi = contributionsApi;
@@ -39,7 +38,7 @@ void CommitGraphScreen::draw() const {
 
   // Draw Github icon and username
   displayController->display.drawBitmap(7, 8, GithubIcon, 16, 16, displayController->colors.foreground);
-  displayController->drawText("/" + String(config->username), 29, 20);
+  displayController->drawText("/" + String(config->commitGraph.username), 29, 20);
 
   // Draw battery percentage
   displayController->drawText(String(getBatteryPercentage()) + "%", displayController->display.width() - 25, 20);
@@ -96,7 +95,7 @@ void CommitGraphScreen::fetchAndDraw() const {
   }
   state->showingWifiError = false;
 
-  CommitGraphContributions newContributions;
+  ContributionsApi::Data newContributions;
   const bool fetchSuccessful = contributionsApi->fetchContributionsData(&newContributions);
   if (!fetchSuccessful) {
     Serial.println("Failed to fetch contributions data");
@@ -130,7 +129,7 @@ void CommitGraphScreen::drawFetchError() const {
 }
 
 void CommitGraphScreen::resetState() const {
-  state->contributions = CommitGraphContributions();
+  state->contributions = ContributionsApi::Data();
   state->showingWifiError = false;
   state->showingFetchError = false;
 }

--- a/src/screens/CommitGraphScreen.h
+++ b/src/screens/CommitGraphScreen.h
@@ -4,18 +4,18 @@
 #include "UserConfig.h"
 #include "WifiController.h"
 
-struct CommitGraphScreenState {
-  CommitGraphContributions contributions;
-  bool showingWifiError = false;
-  bool showingFetchError = false;
-
-  bool storeContributionIfChanged(const CommitGraphContributions *newContributions);
-};
-
 class CommitGraphScreen {
  public:
+  struct State {
+    ContributionsApi::Data contributions;
+    bool showingWifiError = false;
+    bool showingFetchError = false;
+
+    bool storeContributionIfChanged(const ContributionsApi::Data *newContributions);
+  };
+
   explicit CommitGraphScreen(DisplayController *displayController, WifiController *wifiController,
-                             ContributionsApi *contributionsApi, UserConfig *config, CommitGraphScreenState *state);
+                             ContributionsApi *contributionsApi, UserConfig *config, State *state);
   void fetchAndDraw() const;
   void resetState() const;
 
@@ -25,7 +25,7 @@ class CommitGraphScreen {
   void drawFetchError() const;
   DisplayController *displayController;
   WifiController *wifiController;
-  CommitGraphScreenState *state;
   ContributionsApi *contributionsApi;
   UserConfig *config;
+  State *state;
 };


### PR DESCRIPTION
Introduces NVS as the storage for UserConfig. NVS will be used for config user has to enter, and RTC will continue to be used for fetch data. NVS writes to flash, so it shouldn't be used for data changing regularly, however it will persist when power is completely removed. This means that for the LilyGo devices, when the battery is disconnected, the device can retain its config.

- **NVS (Non-Volatile Storage)**
  - Pros:
     - Wear-leveling built-in
     - Key-value storage
     - Survives power cycles and deep sleep
     - Part of ESP-IDF, well-supported
   - Cons:
     - Limited to 4KB per namespace
     - Slightly more complex API
   - Use when: You need persistent storage that survives power loss
- **RTC Memory**
  - Pros:
    - Very fast access
    - No wear concerns
    - Perfect for temporary data between deep sleeps
  - Cons:
    - Lost on power cycle
    - Limited size (8KB total, less for user data)
  - Use when: You need fast access and data only needs to survive deep sleep

---

Other small changes:
- Moved struct definitions into their parent classes